### PR TITLE
feat(evaluator): Finding ID 追跡で修正ループの精度向上

### DIFF
--- a/dot_config/claude/hooks/executable_post-compact-save.sh
+++ b/dot_config/claude/hooks/executable_post-compact-save.sh
@@ -45,4 +45,15 @@ if [ "$count" -ge 2 ]; then
     echo "⚠ Context reset 推奨: compaction が ${count} 回発生。品質低下の兆候がある場合は claude --continue --fork-session を検討してください。" >&2
 fi
 
+# Evaluator findings checkpoint (compact 後も findings を保持)
+GATE_FILE="$CLAUDE_PROJECT_DIR/ai/state/workflow-gate.json"
+CHECKPOINT_FILE="$STATE_DIR/findings-checkpoint.json"
+if [ -f "$GATE_FILE" ] && command -v jq &>/dev/null; then
+    active=$(jq -r '.evaluator.active_findings // [] | length' "$GATE_FILE" 2>/dev/null || echo "0")
+    if [ "$active" -gt 0 ]; then
+        cp "$GATE_FILE" "$CHECKPOINT_FILE"
+        echo "PostCompact: findings checkpoint saved ($active active findings)" >&2
+    fi
+fi
+
 exit 0

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -375,6 +375,26 @@ async function handleStartupResume(projectDir: string): Promise<void> {
     // No feature list
   }
 
+  // Evaluator findings (persist across compaction)
+  try {
+    const gatePath = `${projectDir}/ai/state/workflow-gate.json`;
+    const gateContent = await readTextFileSafe(gatePath);
+    if (gateContent) {
+      const gate = JSON.parse(gateContent);
+      const findings = gate.evaluator?.findings;
+      if (findings && (findings.new > 0 || findings.persist > 0)) {
+        parts.push(
+          "",
+          "## Evaluator Findings (前回)",
+          `Status: ${gate.evaluator.status} — ${gate.evaluator.summary}`,
+          `NEW: ${findings.new}, PERSIST: ${findings.persist}, RESOLVED: ${findings.resolved}`,
+        );
+      }
+    }
+  } catch {
+    // No workflow-gate.json
+  }
+
   // Context Reset handoff
   try {
     const handoffPath = `${projectDir}/ai/state/handoff.json`;

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -112,6 +112,8 @@ async function getGitShortHead(projectDir: string): Promise<string> {
   }
 }
 
+const FINDINGS_TTL_HOURS = 12;
+
 async function buildFindingsContext(projectDir: string): Promise<string> {
   try {
     const gatePath = `${projectDir}/ai/state/workflow-gate.json`;
@@ -120,6 +122,14 @@ async function buildFindingsContext(projectDir: string): Promise<string> {
     const gate = JSON.parse(gateContent);
     const activeFindings = gate.evaluator?.active_findings;
     if (!activeFindings || activeFindings.length === 0) return "";
+
+    // TTL チェック: updated_at が 12 時間以内かどうか
+    if (gate.updated_at) {
+      const updatedAt = new Date(gate.updated_at).getTime();
+      if (isNaN(updatedAt) || Date.now() - updatedAt > FINDINGS_TTL_HOURS * 3600_000) {
+        return ""; // stale findings — skip injection
+      }
+    }
 
     const lines: string[] = [
       "",

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -98,6 +98,47 @@ Rules:
 
 Call compact_supplement with your analysis.`;
 
+async function getGitShortHead(projectDir: string): Promise<string> {
+  try {
+    const { stdout } = await new Deno.Command("git", {
+      args: ["rev-parse", "--short", "HEAD"],
+      stdout: "piped",
+      stderr: "null",
+      cwd: projectDir,
+    }).output();
+    return new TextDecoder().decode(stdout).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function buildFindingsContext(projectDir: string): Promise<string> {
+  try {
+    const gatePath = `${projectDir}/ai/state/workflow-gate.json`;
+    const gateContent = await readTextFileSafe(gatePath);
+    if (!gateContent) return "";
+    const gate = JSON.parse(gateContent);
+    const activeFindings = gate.evaluator?.active_findings;
+    if (!activeFindings || activeFindings.length === 0) return "";
+
+    const lines: string[] = [
+      "",
+      "## Evaluator Findings (未解決)",
+      `Status: ${gate.evaluator.status} — ${gate.evaluator.summary}`,
+    ];
+    for (const f of activeFindings.slice(0, 5)) {
+      const persist = f.persist_count > 1 ? ` (persist x${f.persist_count})` : "";
+      lines.push(`- [${f.key}][${f.status}${persist}] ${f.path}:${f.line} ${f.summary}`);
+    }
+    if (activeFindings.length > 5) {
+      lines.push(`- ... 他 ${activeFindings.length - 5} 件`);
+    }
+    return lines.join("\n");
+  } catch {
+    return "";
+  }
+}
+
 function outputHookResult(context: string): void {
   const result = {
     hookSpecificOutput: {
@@ -256,8 +297,9 @@ async function handleCompact(
     if (toolBlock && toolBlock.type === "tool_use") {
       const supplement = toolBlock.input as CompactSupplementInput;
       const formatted = formatSupplement(supplement);
-      if (formatted.trim()) {
-        outputHookResult(formatted);
+      const findingsCtx = await buildFindingsContext(projectDir);
+      if (formatted.trim() || findingsCtx) {
+        outputHookResult(formatted + findingsCtx);
       }
     } else {
       await Deno.stderr.write(
@@ -265,6 +307,9 @@ async function handleCompact(
           `SessionStart(compact): No tool_use block in response. stop_reason=${response.stop_reason}\n`,
         ),
       );
+      // Supplement がなくても findings は注入
+      const findingsCtx = await buildFindingsContext(projectDir);
+      if (findingsCtx) outputHookResult(findingsCtx);
     }
   } catch (e) {
     const errName = e instanceof Error ? e.constructor.name : "Unknown";
@@ -274,7 +319,8 @@ async function handleCompact(
         `SessionStart(compact) Haiku error [${errName}]: ${errMsg}\n`,
       ),
     );
-    outputHookResult(buildFallbackMarkdown(assets));
+    const findingsCtx = await buildFindingsContext(projectDir);
+    outputHookResult(buildFallbackMarkdown(assets) + findingsCtx);
   }
 }
 
@@ -381,14 +427,22 @@ async function handleStartupResume(projectDir: string): Promise<void> {
     const gateContent = await readTextFileSafe(gatePath);
     if (gateContent) {
       const gate = JSON.parse(gateContent);
-      const findings = gate.evaluator?.findings;
-      if (findings && (findings.new > 0 || findings.persist > 0)) {
-        parts.push(
-          "",
-          "## Evaluator Findings (前回)",
-          `Status: ${gate.evaluator.status} — ${gate.evaluator.summary}`,
-          `NEW: ${findings.new}, PERSIST: ${findings.persist}, RESOLVED: ${findings.resolved}`,
-        );
+      const activeFindings = gate.evaluator?.active_findings;
+      if (activeFindings && activeFindings.length > 0) {
+        // HEAD 一致チェック
+        const currentSha = await getGitShortHead(projectDir);
+
+        if (gate.head_sha === currentSha) {
+          // HEAD 一致: active findings を詳細注入
+          const findingsCtx = await buildFindingsContext(projectDir);
+          if (findingsCtx) parts.push(findingsCtx);
+        } else {
+          // HEAD 不一致: stale notice のみ
+          parts.push(
+            "",
+            `前回評価 (${gate.head_sha}) は現在の HEAD (${currentSha}) と異なります。再評価推奨。`,
+          );
+        }
       }
     }
   } catch {

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -114,10 +114,15 @@ async function getGitShortHead(projectDir: string): Promise<string> {
 
 const FINDINGS_TTL_HOURS = 12;
 
-async function buildFindingsContext(projectDir: string): Promise<string> {
+async function buildFindingsContext(projectDir: string, sessionId?: string): Promise<string> {
   try {
-    const gatePath = `${projectDir}/ai/state/workflow-gate.json`;
-    const gateContent = await readTextFileSafe(gatePath);
+    // Primary: workflow-gate.json, Fallback: findings-checkpoint.json
+    let gateContent = await readTextFileSafe(`${projectDir}/ai/state/workflow-gate.json`);
+    if (!gateContent && sessionId) {
+      gateContent = await readTextFileSafe(
+        `${projectDir}/ai/state/${sessionId}/findings-checkpoint.json`,
+      );
+    }
     if (!gateContent) return "";
     const gate = JSON.parse(gateContent);
     const activeFindings = gate.evaluator?.active_findings;
@@ -307,7 +312,7 @@ async function handleCompact(
     if (toolBlock && toolBlock.type === "tool_use") {
       const supplement = toolBlock.input as CompactSupplementInput;
       const formatted = formatSupplement(supplement);
-      const findingsCtx = await buildFindingsContext(projectDir);
+      const findingsCtx = await buildFindingsContext(projectDir, sessionId);
       if (formatted.trim() || findingsCtx) {
         outputHookResult(formatted + findingsCtx);
       }
@@ -318,7 +323,7 @@ async function handleCompact(
         ),
       );
       // Supplement がなくても findings は注入
-      const findingsCtx = await buildFindingsContext(projectDir);
+      const findingsCtx = await buildFindingsContext(projectDir, sessionId);
       if (findingsCtx) outputHookResult(findingsCtx);
     }
   } catch (e) {
@@ -329,7 +334,7 @@ async function handleCompact(
         `SessionStart(compact) Haiku error [${errName}]: ${errMsg}\n`,
       ),
     );
-    const findingsCtx = await buildFindingsContext(projectDir);
+    const findingsCtx = await buildFindingsContext(projectDir, sessionId);
     outputHookResult(buildFallbackMarkdown(assets) + findingsCtx);
   }
 }

--- a/dot_config/claude/skills/evaluator/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/evaluator/INSTRUCTIONS.md
@@ -72,34 +72,42 @@
 
 ### 総合判定: FAIL (1基準が閾値未達)
 
-### 具体的な問題（Finding ID 付き）
+### 具体的な問題（Finding 追跡付き）
 
-各問題に一意の finding_id を付与する。形式: `EVAL-{status}-{file}-L{line}`
+各問題に安定した finding key を付与する。key は `EVAL-{category}-{N}` 形式（永続、status や行番号に依存しない）。
+category: `ERR`, `PERF`, `TEST`, `SEC`, `UX`, `SPEC`
 
-1. [EVAL-NEW-users-ts-L42] エラーハンドリング (FAIL)
+初回評価の例:
+1. **[EVAL-ERR-1]** エラーハンドリング (FAIL)
+   - status: NEW
+   - path: src/routes/users.ts:42
    - `/api/users/999` が 500 を返す（期待: 404）
-   - ファイル: src/routes/users.ts:42
    - 原因: findById の null チェック欠落
 
-2. [EVAL-NEW-users-ts-L15] パフォーマンス (WARNING)
+2. **[EVAL-PERF-1]** パフォーマンス (WARNING)
+   - status: NEW
+   - path: src/routes/users.ts:15
    - `/api/users` で全件取得後にフィルタリング
-   - 改善案: WHERE 句でフィルタリング
 
-### 再評価時の追跡
+### 再評価時の Finding 追跡
 
-再評価（2回目以降）では、前回の finding_id を追跡する:
+再評価（2回目以降）では、まず `ai/state/workflow-gate.json` を読み、前回の `active_findings` と今回の findings を照合する。
+同じ問題には前回と同じ key を再利用し、status を更新する:
 
-- **EVAL-RESOLVED-xxx**: 前回の指摘が修正された
-- **EVAL-PERSIST-xxx**: 前回の指摘が未修正のまま残っている
-- **EVAL-NEW-xxx**: 今回新たに発見された問題
+- **NEW**: 今回新たに発見された問題（新しい key を採番）
+- **PERSIST**: 前回の指摘が未修正（同じ key、persist_count +1）
+- **RESOLVED**: 前回の指摘が修正された（レポートに記録、active_findings からは除外）
 
-例:
-- [EVAL-RESOLVED-users-ts-L42] null チェック追加を確認 → 修正済み
-- [EVAL-PERSIST-users-ts-L15] パフォーマンス → 未修正
-- [EVAL-NEW-auth-ts-L88] トークン検証の例外処理欠落
+照合基準: 同じ category + 同じファイル + 類似の症状 → 同一 finding。
+summary は事実ベースで安定した表現を使い、前回と同じ finding には前回の wording を再利用する。
+
+再評価の例:
+- **[EVAL-ERR-1]** status: RESOLVED — null チェック追加を確認
+- **[EVAL-PERF-1]** status: PERSIST (persist_count: 2) — 未修正
+- **[EVAL-SEC-1]** status: NEW — トークン検証の例外処理欠落
 
 ### 次のアクション
-- [ ] 全 PERSIST finding を修正
+- [ ] 全 PERSIST finding を修正（persist_count 2以上は優先）
 - [ ] 全 NEW finding を修正（WARNING は推奨）
 ```
 
@@ -120,28 +128,36 @@
 
 ```bash
 mkdir -p ai/state
-cat > ai/state/workflow-gate.json << GATE
+cat > ai/state/workflow-gate.json << 'GATE'
 {
-  "branch": "$(git branch --show-current)",
-  "head_sha": "$(git rev-parse --short HEAD)",
+  "schema_version": 2,
+  "branch": "{current branch}",
+  "head_sha": "{short HEAD}",
   "evaluator": {
     "status": "{PASS|FAIL|BLOCKED|NOT_EVALUABLE}",
     "summary": "{1行の評価サマリー}",
-    "findings": {
-      "new": 0,
-      "persist": 0,
-      "resolved": 0
-    }
+    "findings_count": { "new": 0, "persist": 0, "resolved": 0 },
+    "active_findings": [
+      {
+        "key": "EVAL-ERR-1",
+        "category": "ERR",
+        "status": "PERSIST",
+        "summary": "users by id returns 500 instead of 404",
+        "path": "src/routes/users.ts",
+        "line": 42,
+        "persist_count": 2
+      }
+    ]
   },
-  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  "updated_at": "{ISO timestamp}"
 }
 GATE
 ```
 
-- PASS: 全基準が閾値を超えた
-- FAIL: 1つ以上の基準が閾値未達
-- BLOCKED: 環境問題で評価実行不能
-- NOT_EVALUABLE: ドキュメントのみ・設定変更のみ等、評価基準のスコープ外
+- `branch`, `head_sha`, `updated_at` は実際の値を埋める
+- `active_findings` には **未解決の finding のみ** を含める（RESOLVED は除外）
+- `persist_count` は前回の値 +1（NEW なら 1）
+- PASS 時は `active_findings: []`
 
 **receipt は必ず記録する。** FAIL でも BLOCKED でも記録すること。
 

--- a/dot_config/claude/skills/evaluator/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/evaluator/INSTRUCTIONS.md
@@ -72,26 +72,44 @@
 
 ### 総合判定: FAIL (1基準が閾値未達)
 
-### 具体的な問題
-1. [FAIL] エラーハンドリング
+### 具体的な問題（Finding ID 付き）
+
+各問題に一意の finding_id を付与する。形式: `EVAL-{status}-{file}-L{line}`
+
+1. [EVAL-NEW-users-ts-L42] エラーハンドリング (FAIL)
    - `/api/users/999` が 500 を返す（期待: 404）
    - ファイル: src/routes/users.ts:42
    - 原因: findById の null チェック欠落
 
-2. [WARNING] パフォーマンス
+2. [EVAL-NEW-users-ts-L15] パフォーマンス (WARNING)
    - `/api/users` で全件取得後にフィルタリング
    - 改善案: WHERE 句でフィルタリング
 
+### 再評価時の追跡
+
+再評価（2回目以降）では、前回の finding_id を追跡する:
+
+- **EVAL-RESOLVED-xxx**: 前回の指摘が修正された
+- **EVAL-PERSIST-xxx**: 前回の指摘が未修正のまま残っている
+- **EVAL-NEW-xxx**: 今回新たに発見された問題
+
+例:
+- [EVAL-RESOLVED-users-ts-L42] null チェック追加を確認 → 修正済み
+- [EVAL-PERSIST-users-ts-L15] パフォーマンス → 未修正
+- [EVAL-NEW-auth-ts-L88] トークン検証の例外処理欠落
+
 ### 次のアクション
-- [ ] users.ts:42 に null チェック追加
-- [ ] users クエリにページネーション追加（推奨）
+- [ ] 全 PERSIST finding を修正
+- [ ] 全 NEW finding を修正（WARNING は推奨）
 ```
 
 ### 5. フィードバックループ
 
-- FAIL 判定 → Generator に具体的フィードバックを返す
+- FAIL 判定 → Generator に finding_id 付きフィードバックを返す
 - Generator が修正 → 再評価（最大3回）
+  - 再評価時は前回の finding_id を追跡し、RESOLVED/PERSIST/NEW を明示
 - 3回 FAIL → ユーザーにエスカレーション
+- **スタック検知**: 同じ finding_id が 2回連続 PERSIST → その finding は Generator が自力で解決できない可能性が高い。ユーザーにエスカレーションするか、別のアプローチを提案
 - PASS → 完了報告
 - **BLOCKED** → 環境起動不可、外部API不達等で評価実行不能。理由を報告し、手動検証を推奨
 - **NOT_EVALUABLE** → 変更が評価基準のスコープ外（ドキュメントのみ、設定変更のみ等）。スキップを報告
@@ -108,7 +126,12 @@ cat > ai/state/workflow-gate.json << GATE
   "head_sha": "$(git rev-parse --short HEAD)",
   "evaluator": {
     "status": "{PASS|FAIL|BLOCKED|NOT_EVALUABLE}",
-    "summary": "{1行の評価サマリー}"
+    "summary": "{1行の評価サマリー}",
+    "findings": {
+      "new": 0,
+      "persist": 0,
+      "resolved": 0
+    }
   },
   "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }


### PR DESCRIPTION
## Summary

takt フレームワークの validation output contract パターンを参考に、evaluator に Finding ID 追跡を導入。

## Changes

### evaluator INSTRUCTIONS.md
- Finding ID 形式を導入: `EVAL-{NEW|PERSIST|RESOLVED}-{file}-L{line}`
- 再評価時に前回の finding を追跡し `NEW / PERSIST / RESOLVED` を明示
- 同じ finding が 2回連続 PERSIST → スタック検知 → エスカレーション
- workflow-gate.json の receipt に findings count (new/persist/resolved) を追加

### session-start.ts
- SessionStart(startup|resume) で `workflow-gate.json` の evaluator findings を自動注入
- compact 後も前回の evaluator 指摘が失われない

## Motivation

- 記事: "evaluator identifies legitimate issues, then talks itself into deciding they weren't a big deal"
- takt: validation.md で finding_id を付与し new/persists/resolved を追跡
- 現状の問題: evaluator の FAIL → fix → 再評価で「前回と同じ問題が残っているか」を構造的に判定できない

## Test plan

- [ ] `/evaluator` 実行時に finding_id 付きレポートが生成されるか確認
- [ ] 再評価時に PERSIST/RESOLVED が正しく追跡されるか確認
- [ ] compact 後の SessionStart で前回の findings が注入されるか確認