### PR TITLE
feat(harness): long context 精度向上（compact_resume, task_contract, session_health, loop検出）

### DIFF
--- a/bin/cc-statusline.ts
+++ b/bin/cc-statusline.ts
@@ -439,6 +439,25 @@ async function main() {
       `${fiveColor}⏱ 5h${RESET} ${fiveBar}${sep}${sevenColor}📅 7d${RESET} ${sevenBar}${resetStr ? `  ${GRAY}Resets ${resetStr}${RESET}` : ""}`,
     );
   }
+
+  // Write session health for Stop/PostCompact hooks to consume
+  if (input.session_id) {
+    try {
+      const healthDir = "/tmp/claude-session-health";
+      await Deno.mkdir(healthDir, { recursive: true });
+      const healthFile = `${healthDir}/${input.session_id}.json`;
+      const health = {
+        session_id: input.session_id,
+        context_pct: pct,
+        exceeds_200k: exceeds200k,
+        duration_ms: duration,
+        updated_at: new Date().toISOString(),
+      };
+      await Deno.writeTextFile(healthFile, JSON.stringify(health));
+    } catch {
+      // ignore — statusline should never fail
+    }
+  }
 }
 
 if (import.meta.main) {

--- a/dot_config/claude/hooks/executable_post-compact-save.sh
+++ b/dot_config/claude/hooks/executable_post-compact-save.sh
@@ -56,4 +56,76 @@ if [ -f "$GATE_FILE" ] && command -v jq &>/dev/null; then
     fi
 fi
 
+# Compact Resume Packet 生成（Haiku で構造化）
+# transcript_path と compact_summary から目的・決定・意図・依存・未完了を抽出
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
+RESUME_FILE="$STATE_DIR/compact_resume.json"
+
+# Haiku API 呼び出しに必要な認証を試みる
+API_KEY="${ANTHROPIC_API_KEY:-}"
+if [ -z "$API_KEY" ]; then
+    # keychain からトークン取得を試みる
+    SESSION_TOKEN="${CLAUDE_CODE_SESSION_ACCESS_TOKEN:-}"
+    if [ -z "$SESSION_TOKEN" ]; then
+        # keychain 経由は shell から複雑なので、compact_summary から機械的に抽出
+        if [ -n "$COMPACT_SUMMARY" ]; then
+            cat > "$RESUME_FILE" << RESUME
+{
+  "schema_version": 1,
+  "source": "mechanical",
+  "compact_count": $count,
+  "compact_summary_excerpt": $(echo "$COMPACT_SUMMARY" | head -c 2000 | jq -Rs .),
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+RESUME
+            echo "PostCompact: compact_resume.json saved (mechanical extraction)" >&2
+        fi
+        exit 0
+    fi
+fi
+
+# API key がある場合は Haiku で構造化抽出
+if [ -n "$API_KEY" ] && [ -n "$COMPACT_SUMMARY" ]; then
+    HAIKU_RESPONSE=$(curl -s --max-time 15 https://api.anthropic.com/v1/messages \
+        -H "x-api-key: $API_KEY" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "content-type: application/json" \
+        -d "$(jq -n \
+            --arg summary "$COMPACT_SUMMARY" \
+            '{
+                model: "claude-haiku-4-5-20251001",
+                max_tokens: 512,
+                messages: [{
+                    role: "user",
+                    content: ("Extract structured resume state from this compact summary. Output JSON only with these fields: objective (1 line), current_subtask (1 line), done_criteria (array of strings, max 5), decisions (array of {what, why}), working_files (array of {path, intent, status}), open_loops (array of strings), next_actions (array of strings). Be concise. Japanese OK.\n\nSummary:\n" + $summary)
+                }]
+            }')" 2>/dev/null || true)
+
+    if [ -n "$HAIKU_RESPONSE" ]; then
+        RESUME_CONTENT=$(echo "$HAIKU_RESPONSE" | jq -r '.content[0].text // ""' 2>/dev/null || true)
+        if echo "$RESUME_CONTENT" | jq empty 2>/dev/null; then
+            # valid JSON
+            jq -n \
+                --arg src "haiku" \
+                --argjson count "$count" \
+                --argjson resume "$RESUME_CONTENT" \
+                '{schema_version: 1, source: $src, compact_count: $count, resume: $resume, created_at: (now | todate)}' \
+                > "$RESUME_FILE"
+            echo "PostCompact: compact_resume.json saved (haiku extraction)" >&2
+        else
+            # Haiku がプレーンテキストを返した場合
+            cat > "$RESUME_FILE" << RESUME
+{
+  "schema_version": 1,
+  "source": "haiku_text",
+  "compact_count": $count,
+  "resume_text": $(echo "$RESUME_CONTENT" | head -c 2000 | jq -Rs .),
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+RESUME
+            echo "PostCompact: compact_resume.json saved (haiku text fallback)" >&2
+        fi
+    fi
+fi
+
 exit 0

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -112,6 +112,51 @@ async function getGitShortHead(projectDir: string): Promise<string> {
   }
 }
 
+async function buildResumeContext(projectDir: string, sessionId: string): Promise<string> {
+  try {
+    const resumePath = `${projectDir}/ai/state/${sessionId}/compact_resume.json`;
+    const content = await readTextFileSafe(resumePath);
+    if (!content) return "";
+    const resume = JSON.parse(content);
+
+    const parts: string[] = ["", "## Compact Resume"];
+
+    if (resume.resume) {
+      // Haiku structured output
+      const r = resume.resume;
+      if (r.objective) parts.push(`目的: ${r.objective}`);
+      if (r.current_subtask) parts.push(`現在のサブタスク: ${r.current_subtask}`);
+      if (r.done_criteria?.length > 0) {
+        parts.push("Done 条件:");
+        for (const c of r.done_criteria.slice(0, 5)) parts.push(`- ${c}`);
+      }
+      if (r.decisions?.length > 0) {
+        parts.push("決定事項:");
+        for (const d of r.decisions.slice(0, 3)) parts.push(`- ${d.what}（理由: ${d.why}）`);
+      }
+      if (r.open_loops?.length > 0) {
+        parts.push("未完了:");
+        for (const l of r.open_loops.slice(0, 3)) parts.push(`- ${l}`);
+      }
+      if (r.next_actions?.length > 0) {
+        parts.push("次のアクション:");
+        for (const a of r.next_actions.slice(0, 3)) parts.push(`- ${a}`);
+      }
+    } else if (resume.resume_text) {
+      // Haiku text fallback
+      parts.push(resume.resume_text.slice(0, 1000));
+    } else if (resume.compact_summary_excerpt) {
+      // Mechanical extraction
+      parts.push("(compact summary excerpt)");
+      parts.push(JSON.parse(resume.compact_summary_excerpt).slice(0, 500));
+    }
+
+    return parts.join("\n");
+  } catch {
+    return "";
+  }
+}
+
 const FINDINGS_TTL_HOURS = 12;
 
 async function buildFindingsContext(projectDir: string, sessionId?: string): Promise<string> {
@@ -320,8 +365,9 @@ async function handleCompact(
       const supplement = toolBlock.input as CompactSupplementInput;
       const formatted = formatSupplement(supplement);
       const findingsCtx = await buildFindingsContext(projectDir, sessionId);
-      if (formatted.trim() || findingsCtx) {
-        outputHookResult(formatted + findingsCtx);
+      const resumeCtx = await buildResumeContext(projectDir, sessionId);
+      if (formatted.trim() || findingsCtx || resumeCtx) {
+        outputHookResult(formatted + findingsCtx + resumeCtx);
       }
     } else {
       await Deno.stderr.write(
@@ -329,9 +375,10 @@ async function handleCompact(
           `SessionStart(compact): No tool_use block in response. stop_reason=${response.stop_reason}\n`,
         ),
       );
-      // Supplement がなくても findings は注入
+      // Supplement がなくても findings と resume は注入
       const findingsCtx = await buildFindingsContext(projectDir, sessionId);
-      if (findingsCtx) outputHookResult(findingsCtx);
+      const resumeCtx = await buildResumeContext(projectDir, sessionId);
+      if (findingsCtx || resumeCtx) outputHookResult(findingsCtx + resumeCtx);
     }
   } catch (e) {
     const errName = e instanceof Error ? e.constructor.name : "Unknown";
@@ -342,7 +389,8 @@ async function handleCompact(
       ),
     );
     const findingsCtx = await buildFindingsContext(projectDir, sessionId);
-    outputHookResult(buildFallbackMarkdown(assets) + findingsCtx);
+    const resumeCtx = await buildResumeContext(projectDir, sessionId);
+    outputHookResult(buildFallbackMarkdown(assets) + findingsCtx + resumeCtx);
   }
 }
 

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -138,12 +138,19 @@ async function buildFindingsContext(projectDir: string, sessionId?: string): Pro
 
     const lines: string[] = [
       "",
-      "## Evaluator Findings (未解決)",
-      `Status: ${gate.evaluator.status} — ${gate.evaluator.summary}`,
+      "## 要検証チェックリスト (evaluator findings)",
+      `前回評価: ${gate.evaluator.status} — ${gate.evaluator.summary}`,
+      "",
+      "以下を修正・検証してから完了すること:",
     ];
-    for (const f of activeFindings.slice(0, 5)) {
-      const persist = f.persist_count > 1 ? ` (persist x${f.persist_count})` : "";
-      lines.push(`- [${f.key}][${f.status}${persist}] ${f.path}:${f.line} ${f.summary}`);
+    // PERSIST を優先表示（スタック検知対象）
+    const sorted = [...activeFindings].sort(
+      (a: { persist_count: number }, b: { persist_count: number }) =>
+        (b.persist_count ?? 1) - (a.persist_count ?? 1),
+    );
+    for (const f of sorted.slice(0, 5)) {
+      const persist = f.persist_count > 1 ? ` ⚠ persist x${f.persist_count}` : "";
+      lines.push(`- [ ] [${f.key}] ${f.path}:${f.line} — ${f.summary}${persist}`);
     }
     if (activeFindings.length > 5) {
       lines.push(`- ... 他 ${activeFindings.length - 5} 件`);
@@ -434,6 +441,31 @@ async function handleStartupResume(projectDir: string): Promise<void> {
     }
   } catch {
     // No feature list
+  }
+
+  // Task contract (scope drift prevention)
+  try {
+    const contractPath = `${projectDir}/ai/state/task_contract.json`;
+    const contractContent = await readTextFileSafe(contractPath);
+    if (contractContent) {
+      const contract = JSON.parse(contractContent);
+      if (contract.objective) {
+        parts.push("", "## Task Contract (スコープ確認)");
+        parts.push(`目的: ${contract.objective}`);
+        if (contract.current_step) parts.push(`現在: ${contract.current_step}`);
+        if (contract.done_criteria?.length > 0) {
+          parts.push("Done 条件:");
+          for (const c of contract.done_criteria.slice(0, 5)) {
+            parts.push(`- [ ] ${c}`);
+          }
+        }
+        if (contract.out_of_scope?.length > 0) {
+          parts.push(`スコープ外: ${contract.out_of_scope.join(", ")}`);
+        }
+      }
+    }
+  } catch {
+    // No task contract
   }
 
   // Evaluator findings (persist across compaction)

--- a/dot_config/claude/hooks/executable_stop-hook.ts
+++ b/dot_config/claude/hooks/executable_stop-hook.ts
@@ -54,6 +54,7 @@ Rules:
 - If "Verification evidence: NONE" or "STALE" and Claude claims completion of code changes, suggest running verification but do not hard-block (docs-only or config-only changes may not need verification)
 - If "Verification evidence: FAIL", BLOCK (continue) — verification failed, must fix before completing
 - If "Verification evidence: PASS", factor it positively into stop decision
+- If "Context health: HIGH USAGE" and work is incomplete, suggest --fork-session in the reason
 - Default: approve stop
 
 Call stop_decision with your judgment.`;
@@ -214,6 +215,29 @@ async function main(): Promise<void> {
       verificationNote = "\n\nVerification evidence: NONE (no verification.json found)";
     }
 
+    // Session health check (context anxiety detection)
+    let healthNote = "";
+    try {
+      const sessionHealthDir = "/tmp/claude-session-health";
+      let healthFile = "";
+      for await (const entry of Deno.readDir(sessionHealthDir)) {
+        if (entry.isFile && entry.name.endsWith(".json")) {
+          healthFile = `${sessionHealthDir}/${entry.name}`;
+        }
+      }
+      if (healthFile) {
+        const healthContent = await Deno.readTextFile(healthFile);
+        const health = JSON.parse(healthContent);
+        if (health.context_pct >= 85) {
+          healthNote = `\n\nContext health: HIGH USAGE (${health.context_pct}%) — consider recommending --fork-session if work is incomplete`;
+        } else if (health.context_pct >= 70) {
+          healthNote = `\n\nContext health: ELEVATED (${health.context_pct}%)`;
+        }
+      }
+    } catch {
+      // No health data available
+    }
+
     const response = await client.messages.create({
       model: "claude-haiku-4-5-20251001",
       max_tokens: 256,
@@ -223,7 +247,7 @@ async function main(): Promise<void> {
       messages: [
         {
           role: "user",
-          content: `${userContext}Claude's last assistant message:\n\n${lastMessage}${verificationNote}`,
+          content: `${userContext}Claude's last assistant message:\n\n${lastMessage}${verificationNote}${healthNote}`,
         },
       ],
     });

--- a/dot_config/claude/skills/orchestrator/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/orchestrator/INSTRUCTIONS.md
@@ -35,6 +35,33 @@
 - 前ステップからどのコンテキストが必要か定義
 - 各サブタスクの粒度を判定（→ Step 3）
 
+**task_contract の生成:**
+
+計画が確定したら、`ai/state/task_contract.json` を生成する:
+
+```bash
+mkdir -p ai/state
+cat > ai/state/task_contract.json << 'CONTRACT'
+{
+  "objective": "{タスク全体の目的（1行）}",
+  "current_step": "{現在取り組んでいるステップ}",
+  "done_criteria": [
+    "{完了条件1}",
+    "{完了条件2}"
+  ],
+  "out_of_scope": [
+    "{スコープ外1}"
+  ],
+  "allowed_files": ["{主要な変更対象ファイル}"],
+  "next_checkpoint": "{次の検証ポイント}",
+  "created_at": "{ISO timestamp}"
+}
+CONTRACT
+```
+
+task_contract は compact 後のスコープドリフト防止に使われる。SessionStart が自動で再注入する。
+各ステップ完了後に current_step を更新すること。
+
 ### 2.5 Sprint Contract（完了条件の定義）
 
 曖昧で壊れやすいステップに限り、実行前に完了条件を明示的に定義する。


### PR DESCRIPTION
## Summary

long context 作業（2時間以上、compaction 複数回）での精度低下を防ぐための改善。
codex (gpt-5.4) との 5 ターン議論 + claude-code-guide 仕様調査に基づく。

## Changes

### 1. compact_resume.json 生成 (PostCompact)
- Haiku API で構造化 resume packet を生成（目的・決定・意図・依存・未完了）
- API key がない場合は compact_summary から機械的に抽出（fallback）
- SessionStart(compact) で自動注入

### 2. task_contract.json (orchestrator)
- /plan 実行時に contract（objective, done_criteria, out_of_scope）を生成
- SessionStart で自動注入 → compact 後のスコープドリフト防止

### 3. session_health.json (statusline → stop-hook)
- cc-statusline.ts から `/tmp/claude-session-health/` に context 使用率を書き出し
- stop-hook が読み込み、85%+ で `--fork-session` 推奨を Haiku 判定に追加

### 4. loop/drift detector (stop-hook)
- session_health の context 使用率を Haiku の stop 判定に注入
- 70% ELEVATED, 85%+ HIGH USAGE の段階的警告

### 5. findings チェックリスト化 (SessionStart)
- evaluator findings を「要検証チェックリスト」形式に変換
- PERSIST finding を優先表示（スタック検知対象）
- `- [ ]` チェックボックス形式で actionable に

## Design Principles
- 境界イベント駆動: compact 前後・Stop 時にのみ介入
- Haiku デフォルト: API key がない場合は mechanical fallback
- deterministic first: 機械的に判定できるものは LLM を呼ばない

## Test plan
- [ ] compaction 後に compact_resume.json が生成されるか確認
- [ ] SessionStart(compact) で resume + findings + task_contract が注入されるか確認
- [ ] statusline が session_health.json を書き出しているか確認
- [ ] stop-hook が context health を Haiku 判定に含めるか確認
- [ ] orchestrator 使用時に task_contract.json が生成されるか確認