### PR TITLE
fix(tmux): issue picker bind を M-C から M-i に変更 (aerospace 衝突回避)

### DIFF
--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -4,8 +4,10 @@
       new_issue_cmd = "/path/to/private/hub/scripts/new-issue-session.sh"
       start_task_cmd = "/path/to/private/hub/scripts/start-task.sh"
       repo = "org/hub-repo"
-  When unset, M-C falls back to plain `new-session` and hub-specific
+  When unset, M-i falls back to plain `new-session` and hub-specific
   bindings are omitted. Keeps this public config vendor-neutral.
+  Note: Alt+C / Alt+Shift+C are reserved by aerospace (workspace C),
+  so the issue picker uses Alt+i (mnemonic: issue) instead.
 */ -}}
 {{- $newIssueCmd := dig "hub" "new_issue_cmd" "" . -}}
 # =============================================================================
@@ -113,10 +115,12 @@ bind -n M-Right run "tmux swap-window -t +1 && tmux next-window"
 bind a setw synchronize-panes \; display "synchronize-panes #{?pane_synchronized,on,off}"
 
 # セッション操作
+# Alt+i でこのバインドを発火する。Alt+C / Alt+Shift+C は aerospace が
+# workspace C (Communication) に予約しているため、tmux まで届かない。
 {{- if $newIssueCmd }}
-bind -n "M-C" display-popup -E -w 80% -h 70% {{ $newIssueCmd | quote }}
+bind -n "M-i" display-popup -E -w 80% -h 70% {{ $newIssueCmd | quote }}
 {{- else }}
-bind -n M-C new-session
+bind -n M-i new-session
 {{- end }}
 
 # fzf連携 (-k でキー押下で閉じる)


### PR DESCRIPTION
## Summary

先日 merge した `feat/tmux-claude-pane-monitor` で hub の issue picker bind に `M-C` (Alt+Shift+C) を使ったが、macOS 側の aerospace tiling WM が **Alt+C と Alt+Shift+C を workspace C (Communication/Slack) に予約**しており、tmux まで届かず bind が発火しない事象があった。

aerospace 未使用の letter に回避。**`M-i`** を採用 (mnemonic: issue)。

## 検証

`dot_config/aerospace/aerospace.toml` が占有している letter:
`c, e, f, h, j, k, l, n, t, w, z` (+ Alt+Shift+X 変種)

空き letter: `a, b, d, g, i, m, o, p, q, r, s, u, v, x, y`

aerospace 側 alt-i なし、既存 tmux.conf.tmpl でも M-i は未使用、wezterm の `use_dead_keys = false` 設定で Option+i が dead key として潰れる懸念も低い (codex 確認済)。

## 変更

- `dot_config/tmux/tmux.conf.tmpl:118-124` の bind を `M-C` → `M-i` に rename
- コメント行 (L1-9) を M-i 基準に更新、aerospace との衝突理由を明記

## Test plan

- [x] chezmoi execute-template で both [data.hub] set/unset で正しく render される
- [x] grep で M-C 残存参照なし (コミット message の説明文のみ)
- [ ] chezmoi apply + tmux source 後、Option+i で popup 発火を実機確認