### PR TITLE
feat(claude): codex-tmux 用に cage codex 呼び出しを allow

### DIFF
--- a/dot_config/claude/settings.json.tmpl
+++ b/dot_config/claude/settings.json.tmpl
@@ -68,6 +68,7 @@
       "Bash(make *)",
       "Bash(gh *)",
       "Bash(chezmoi *)",
+      "Bash(cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox *)",
       "Bash(pup *)",
       "Bash(ls *)",
       "Bash(cat *)",


### PR DESCRIPTION
## Summary

- Claude Code の security hardening (v2.1.113+) で `--dangerously-bypass-approvals-and-sandbox` を含む bash コマンドが hard-coded block されるようになった
- これにより codex-tmux skill (`~/.config/claude/skills/codex-tmux/INSTRUCTIONS.md`) の invocation が denied される回帰
- `settings.json.tmpl` の `permissions.allow` に `cage -- codex ...` を明示追加して復旧

## Scope

- `cage` 経由の codex のみ許可 (bare `codex` 直呼びは引き続き要プロンプト)
- 他の設定変更なし

## Test plan

- [x] `chezmoi execute-template` で展開成功、jq で rule 存在確認済み
- [ ] merge 後に `chezmoi apply ~/.config/claude/settings.json` で反映
- [ ] codex-tmux skill を起動して denied されないことを確認