### PR TITLE
feat(tmux): M-m で PM session 切替 binding

### DIFF
--- a/dot_config/tmux/tmux.conf.tmpl
+++ b/dot_config/tmux/tmux.conf.tmpl
@@ -1,15 +1,18 @@
 {{- /*
   Optional per-machine data (set in ~/.config/chezmoi/chezmoi.toml):
     [data.hub]
-      new_issue_cmd = "/path/to/private/hub/scripts/new-issue-session.sh"
+      new_issue_cmd  = "/path/to/private/hub/scripts/new-issue-session.sh"
+      new_pm_cmd     = "/path/to/private/hub/scripts/new-pm-session.sh"
       start_task_cmd = "/path/to/private/hub/scripts/start-task.sh"
-      repo = "org/hub-repo"
+      repo           = "org/hub-repo"
   When unset, M-i falls back to plain `new-session` and hub-specific
   bindings are omitted. Keeps this public config vendor-neutral.
   Note: Alt+C / Alt+Shift+C are reserved by aerospace (workspace C),
   so the issue picker uses Alt+i (mnemonic: issue) instead.
+  M-m は aerospace と衝突しないことを確認済 (mnemonic: management)。
 */ -}}
 {{- $newIssueCmd := dig "hub" "new_issue_cmd" "" . -}}
+{{- $newPmCmd := dig "hub" "new_pm_cmd" "" . -}}
 # =============================================================================
 # 基本設定
 # =============================================================================
@@ -121,6 +124,13 @@ bind a setw synchronize-panes \; display "synchronize-panes #{?pane_synchronized
 bind -n "M-i" display-popup -E -w 80% -h 70% {{ $newIssueCmd | quote }}
 {{- else }}
 bind -n M-i new-session
+{{- end }}
+
+# PM session (task 管理・board・triage) 切替。IC 作業 session と分離して
+# claude の context window を節約する (mnemonic: M-m = management)。
+# #{client_name} を渡すことで multi-client 時も「押した端末」を切替対象にする。
+{{- if $newPmCmd }}
+bind -n "M-m" run-shell {{ printf "%s '#{client_name}'" $newPmCmd | quote }}
 {{- end }}
 
 # fzf連携 (-k でキー押下で閉じる)


### PR DESCRIPTION
## Summary

- `Option+m` で PM 用 tmux session (`pm`) へ切替/作成する binding を追加
- 目的: task 管理・board 確認・issue triage を個別 issue session と分離し、作業用 claude の context window を節約
- `chezmoi data hub.new_pm_cmd` が設定されている場合のみ bind (public repo は vendor-neutral 維持、既存 `hub.new_issue_cmd` と同パターン)
- aerospace との衝突確認済 (`Option+m` は未使用)

## 実装ポイント

- `#{client_name}` を引数で渡し、script 側が `switch-client -c "$1"` で押した端末を切替対象にする
- multi-client attach 時の誤 client 切替を回避 (codex review 指摘対応)
- private hub script 側の `-c` 対応は backward-compat なので merge 順序不問

## Test plan

- [x] chezmoi execute-template で展開を確認 (`bind -n "M-m" run-shell "/path/to/script '#{client_name}'"`)
- [x] codex review 通過 (2 iter — 初稿で client context blocker 検出、修正後 OK)
- [ ] merge 後、`chezmoi apply ~/.config/tmux/tmux.conf` + `tmux source ~/.config/tmux/tmux.conf` で適用
- [ ] 実機で `Option+m` → `pm` session が作成/切替されることを確認