### PR TITLE
feat(claude): codex-tmux で worktree の trust prompt を -c override で抑止

### DIFF
--- a/dot_codex/private_config.toml
+++ b/dot_codex/private_config.toml
@@ -1,7 +1,7 @@
-model = "gpt-5.4"
+model = "gpt-5.5"
 disable_response_storage = true
 sandbox_mode = "workspace-write"
-model_reasoning_effort = "high"
+model_reasoning_effort = "xhigh"
 web_search = "live"
 
 [features]

--- a/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
@@ -46,11 +46,16 @@ tmux select-pane -t "$CODEX_PANE" -T "codex-<topic>"
 
 # repo root を解決して -c で trust_level=trusted を注入
 # （worktree/サブディレクトリ起動時の "Do you trust this directory?" プロンプトを抑止）
-# 通常 repo の toplevel、git 外なら PWD にフォールバック
-_codex_root=$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null || pwd)
+# 注: codex の -c は dotted key の quoted segment を解釈せず生 split するため、
+#     key 側は単一トークン `projects` のみにして値を inline table で渡す。
+# git 外（toplevel 未解決）では override を付けない（/tmp 等の誤 auto-trust 防止）。
+_codex_root=$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null || true)
 
-# send-keysでcodex起動コマンドを送信
-tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c 'projects.\"$_codex_root\".trust_level=\"trusted\"' \"\$(cat /tmp/codex-prompt.txt)\"" Enter
+if [ -n "$_codex_root" ]; then
+  tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c 'projects={\"$_codex_root\"={trust_level=\"trusted\"}}' \"\$(cat /tmp/codex-prompt.txt)\"" Enter
+else
+  tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox \"\$(cat /tmp/codex-prompt.txt)\"" Enter
+fi
 ```
 
 ### Step 2: 完了検知

--- a/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
@@ -46,10 +46,22 @@ tmux select-pane -t "$CODEX_PANE" -T "codex-<topic>"
 
 # repo root を解決して -c で trust_level=trusted を注入
 # （worktree/サブディレクトリ起動時の "Do you trust this directory?" プロンプトを抑止）
-# 注: codex の -c は dotted key の quoted segment を解釈せず生 split するため、
-#     key 側は単一トークン `projects` のみにして値を inline table で渡す。
-# git 外（toplevel 未解決）では override を付けない（/tmp 等の誤 auto-trust 防止）。
-_codex_root=$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null || true)
+#
+# 注1: codex の -c は dotted key の quoted segment を解釈せず生 split するため、
+#      key 側は単一トークン `projects` のみにして値を inline table で渡す。
+# 注2: Codex 本体の trust lookup は linked worktree を main repo root に正規化する
+#      ため、`--show-toplevel`（worktree root）ではなく `--git-common-dir` の親
+#      （main repo の `.git` の親 = main repo root）を trust target にする。
+#      bare repo / submodule / custom GIT_DIR / 非 git は intentionally no override
+#      （Codex 側の filesystem ベース trust 解決と揃わないので保守的に fallback）。
+# 既知制約: repo root path に `'`, `"`, `\` が含まれると shell/TOML quoting が破綻
+#           （一般的な repo path では踏まない）。
+_git_common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [ -n "$_git_common" ] && [ "$(basename "$_git_common")" = ".git" ]; then
+  _codex_root=$(dirname "$_git_common")
+else
+  _codex_root=""
+fi
 
 if [ -n "$_codex_root" ]; then
   tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c 'projects={\"$_codex_root\"={trust_level=\"trusted\"}}' \"\$(cat /tmp/codex-prompt.txt)\"" Enter

--- a/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
+++ b/dot_config/claude/skills/codex-tmux/INSTRUCTIONS.md
@@ -44,8 +44,13 @@ CODEX_PANE=$(tmux split-window -v -f -d -l 30% -t "$TMUX_PANE" -P -F '#{pane_id}
 # paneにタイトルを設定（トピックに応じた名前をつける）
 tmux select-pane -t "$CODEX_PANE" -T "codex-<topic>"
 
+# repo root を解決して -c で trust_level=trusted を注入
+# （worktree/サブディレクトリ起動時の "Do you trust this directory?" プロンプトを抑止）
+# 通常 repo の toplevel、git 外なら PWD にフォールバック
+_codex_root=$(git rev-parse --path-format=absolute --show-toplevel 2>/dev/null || pwd)
+
 # send-keysでcodex起動コマンドを送信
-tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox \"\$(cat /tmp/codex-prompt.txt)\"" Enter
+tmux send-keys -t "$CODEX_PANE" "cage -- codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox -c 'projects.\"$_codex_root\".trust_level=\"trusted\"' \"\$(cat /tmp/codex-prompt.txt)\"" Enter
 ```
 
 ### Step 2: 完了検知

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -17,7 +17,7 @@ alias awk='gawk'
 alias killclaude='pkill -f -i claude'
 claude() {
   if [ $# -eq 0 ]; then
-    cage -preset claude-code -- env GIT_EDITOR=true claude --dangerously-skip-permissions --mcp-config=$XDG_CONFIG_HOME/claude/mcp.json pick-task
+    cage -preset claude-code -- env GIT_EDITOR=true claude --dangerously-skip-permissions --mcp-config=$XDG_CONFIG_HOME/claude/mcp.json
   else
     cage -preset claude-code -- env GIT_EDITOR=true claude --dangerously-skip-permissions --mcp-config=$XDG_CONFIG_HOME/claude/mcp.json "$@"
   fi


### PR DESCRIPTION
## Summary
codex-tmux skill の codex 起動コマンドに `-c 'projects={"<main-repo-root>"={trust_level="trusted"}}'` を注入し、worktree / サブディレクトリから起動した際に出る "Do you trust this directory?" プロンプトを抑止する。併せて周辺の小さな設定更新も同梱。

## 背景
worktree のサブディレクトリで codex を起動すると trust prompt が出て対話が中断される。非対話で使いたいため override で抑止したい。

## 実装上のポイント
- **TOML inline-table 構文必須**: codex の `-c` は dotted key の quoted segment を解釈せず `split('.')` するため、`projects."<path>".trust_level=...` では path に `.` が含まれると壊れる。`projects={"<path>"={trust_level="trusted"}}` の inline-table で渡す
- **main repo root を trust target にする**: Codex 本体の `resolve_root_git_project_for_trust()` は linked worktree を main repo root に正規化して lookup するので、`--show-toplevel`（worktree root）ではなく `--git-common-dir` の親（main repo の `.git` の親）を渡す必要がある
- **edge case は意図的に no override**: bare repo / submodule / custom GIT_DIR / 非 git ディレクトリは Codex 側の filesystem ベース trust 解決と揃わないので保守的に override を付けない

## 既知制約
repo root path に `'`, `"`, `\` が含まれる場合は shell / TOML quoting が破綻する（一般的な repo path では踏まない）。INSTRUCTIONS.md にコメントで明記済み。

## 経緯 (codex-tmux 3 commit)
1. `876b378`: 初回実装 (dotted-quoted syntax)
2. `0e6391e`: codex `-c` の parser 特性判明 → inline-table に書き換え
3. `0c8a63f`: Codex 本体の trust lookup が main repo root 期待と判明 → `--git-common-dir` の親に変更

いずれも codex-tmux レビュー (gpt-5.4) を経由、実機で codex 0.124.0 に対して override が parse されることおよび worktree の trust lookup 挙動を検証。

## 付随変更 (2 commit)
- `9147c1c chore(codex)`: `private_config.toml` の model を `gpt-5.5` / reasoning_effort を `xhigh` に更新
- `eb88f7e refactor(zsh)`: 無引数 `claude()` から `pick-task` 起動を削除、通常 REPL 起動に戻す

## Test plan
- [ ] worktree サブディレクトリから codex-tmux 経由で codex 起動 → trust prompt が出ずに対話に入れる
- [ ] 通常 repo の root / サブディレクトリで同様に prompt 抑止される
- [ ] bare repo / submodule / 非 git ディレクトリで override 無しで起動される（保守的 fallback）
- [ ] zsh で無引数 `claude` が REPL 起動する