### PR TITLE
fix(zsh): gw 系関数の local path 衝突で関数内 PATH が破壊される問題を修正

### DIFF
--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -178,31 +178,31 @@ gwn() {
   git wt --nocd "$@"
 }
 gwr() {
-  local selected path branch
+  local selected wt_branch
   selected=$(git wt --json 2>/dev/null | jq -r '.[] | select(.bare == false) | "\(.path)\t\(.branch)"' | fzf --delimiter='\t' \
     --with-nth=2 \
     --preview 'git -C {1} log --oneline -10' \
     --preview-window=right:50%)
-  [[ -n "$selected" ]] && branch=$(echo "$selected" | cut -f2) && git wt -d "$branch"
+  [[ -n "$selected" ]] && wt_branch=$(echo "$selected" | cut -f2) && git wt -d "$wt_branch"
 }
 gwa() {
-  local selected path
+  local selected wt_path
   selected=$(git wt --json 2>/dev/null | jq -r '.[] | select(.bare == false) | "\(.path)\t\(.branch)"' | fzf --delimiter='\t' \
     --with-nth=2 \
     --preview 'git -C {1} log --oneline -10' \
     --preview-window=right:50%)
-  [[ -n "$selected" ]] && path=$(echo "$selected" | cut -f1) && (cd "$path" && cage -preset claude-code -- env GIT_EDITOR=true claude --dangerously-skip-permissions --mcp-config=$XDG_CONFIG_HOME/claude/mcp.json "$@")
+  [[ -n "$selected" ]] && wt_path=$(echo "$selected" | cut -f1) && (cd "$wt_path" && cage -preset claude-code -- env GIT_EDITOR=true claude --dangerously-skip-permissions --mcp-config=$XDG_CONFIG_HOME/claude/mcp.json "$@")
 }
 gwe() {
-  local selected path
+  local selected wt_path
   selected=$(git wt --json 2>/dev/null | jq -r '.[] | select(.bare == false) | "\(.path)\t\(.branch)"' | fzf --delimiter='\t' \
     --with-nth=2 \
     --preview 'git -C {1} log --oneline -10' \
     --preview-window=right:50%)
-  [[ -n "$selected" ]] && path=$(echo "$selected" | cut -f1) && cursor "$path"
+  [[ -n "$selected" ]] && wt_path=$(echo "$selected" | cut -f1) && cursor "$wt_path"
 }
 gw() {
-  local selected path
+  local selected
   selected=$(git wt --json 2>/dev/null | jq -r '.[] | select(.bare == false) | "\(.path)\t\(.branch)"' | fzf --delimiter='\t' \
     --with-nth=2 \
     --preview 'git -C {1} log --oneline -10' \


### PR DESCRIPTION
## Summary
- zsh の `path` は `PATH` と tied scalar/array の特殊変数。`local selected path` で空ローカル化すると関数内の `PATH` も空になる
- `gw` `gwa` `gwe` `gwr` で発生しており、未ハッシュの `jq`/`fzf` が `command not found` で fail（`git` だけ動いていたのは zsh が hash 済みだったため）
- `local path` を `wt_path` / `wt_branch` に rename して衝突回避。`gw` は `$path` 未使用だったので変数自体削除

## Test plan
- [x] 修正適用 + `chezmoi apply` + `relogin` 後、隣 pane で `gw` 実行 → `command not found` が消えることを実環境で確認
- [x] `gwa` `gwe` `gwr` も同じ pattern で修正、diff レビュー OK
- [x] codex (gpt-5) cross-review で blocker 無し、`git diff --check` も通過、merge OK 判定