### PR TITLE
claude/hooks 設定のブラッシュアップ: 認証経路統一・ブロックフック強化・UserPromptSubmit統合

### DIFF
--- a/bin/cc-statusline.ts
+++ b/bin/cc-statusline.ts
@@ -131,8 +131,8 @@ async function findKeychainServices(): Promise<string[]> {
 }
 
 async function getTokenFromKeychain(): Promise<string | null> {
-  const envToken = Deno.env.get("CLAUDE_CODE_OAUTH_TOKEN");
-  if (envToken) return envToken;
+  // claude ランチャが CLAUDE_CODE_OAUTH_TOKEN を unset するため env トークンは
+  // hook/statusline に届かず、keychain の OAuth トークンが唯一の認証経路（env 検査は廃止）。
   try {
     for (const svc of await findKeychainServices()) {
       try {

--- a/dot_config/claude/hooks/executable_post-compact-save.sh
+++ b/dot_config/claude/hooks/executable_post-compact-save.sh
@@ -65,18 +65,44 @@ RESUME_FILE="$STATE_DIR/compact_resume.json"
 # 優先順位: ANTHROPIC_API_KEY (x-api-key) → env OAuth トークン (Bearer)
 #           → keychain OAuth トークン (Bearer)
 # hook プロセスでは env トークンが strip されるため、通常は keychain に落ちる。
+
+# compact_summary から機械的に resume を生成（Haiku 不可・失敗・タイムアウト時の共通フォールバック）
+write_mechanical_resume() {
+    [ -n "$COMPACT_SUMMARY" ] || return 0
+    cat > "$RESUME_FILE" << RESUME
+{
+  "schema_version": 1,
+  "source": "mechanical",
+  "compact_count": $count,
+  "compact_summary_excerpt": $(echo "$COMPACT_SUMMARY" | head -c 2000 | jq -Rs .),
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+RESUME
+    echo "PostCompact: compact_resume.json saved (mechanical extraction)" >&2
+}
+
+# macOS keychain から有効な Claude Code OAuth トークンを取得
+# lib/session-context.ts と同様に全 service を走査し、取得失敗・期限切れは skip して次を試す。
 get_keychain_token() {
     command -v security >/dev/null 2>&1 || return 1
-    local svc raw token expires now
-    svc=$(security dump-keychain 2>/dev/null | grep -oE 'Claude Code-credentials[^"]*' | head -1)
-    if [ -z "$svc" ]; then return 1; fi
-    raw=$(security find-generic-password -s "$svc" -w 2>/dev/null) || return 1
-    token=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
-    if [ -z "$token" ]; then return 1; fi
-    expires=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.expiresAt // 0' 2>/dev/null || echo 0)
+    local services svc raw token expires now
+    services=$(security dump-keychain 2>/dev/null \
+        | grep -oE '"svce"<blob>="Claude Code-credentials[^"]*"' \
+        | sed -E 's/^"svce"<blob>="(.*)"$/\1/' \
+        | awk '!seen[$0]++')
+    if [ -z "$services" ]; then return 1; fi
     now=$(( $(date +%s) * 1000 ))
-    if [ "$expires" != "0" ] && [ "$expires" -lt "$now" ]; then return 1; fi
-    printf '%s' "$token"
+    while IFS= read -r svc; do
+        [ -n "$svc" ] || continue
+        raw=$(security find-generic-password -s "$svc" -w 2>/dev/null) || continue
+        token=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null) || continue
+        [ -n "$token" ] || continue
+        expires=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.expiresAt // 0' 2>/dev/null || echo 0)
+        if [ "$expires" != "0" ] && [ "$expires" -lt "$now" ]; then continue; fi
+        printf '%s' "$token"
+        return 0
+    done <<< "$services"
+    return 1
 }
 
 API_KEY="${ANTHROPIC_API_KEY:-}"
@@ -88,24 +114,14 @@ if [ -z "$API_KEY" ]; then
     fi
 fi
 
-# 認証が全く取れない場合は compact_summary から機械的に抽出して終了
+# 認証が全く取れない場合は機械抽出で終了
 if [ -z "$API_KEY" ] && [ -z "$OAUTH_TOKEN" ]; then
-    if [ -n "$COMPACT_SUMMARY" ]; then
-        cat > "$RESUME_FILE" << RESUME
-{
-  "schema_version": 1,
-  "source": "mechanical",
-  "compact_count": $count,
-  "compact_summary_excerpt": $(echo "$COMPACT_SUMMARY" | head -c 2000 | jq -Rs .),
-  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-RESUME
-        echo "PostCompact: compact_resume.json saved (mechanical extraction)" >&2
-    fi
+    write_mechanical_resume
     exit 0
 fi
 
 # Haiku で構造化抽出（API key は x-api-key、OAuth トークンは Bearer + beta ヘッダ）
+# curl の --max-time は PostCompact hook timeout(10s)未満に収め、超過/失敗時は機械抽出へ。
 if [ -n "$COMPACT_SUMMARY" ]; then
     if [ -n "$API_KEY" ]; then
         auth_args=(-H "x-api-key: $API_KEY")
@@ -113,7 +129,7 @@ if [ -n "$COMPACT_SUMMARY" ]; then
         auth_args=(-H "authorization: Bearer $OAUTH_TOKEN" -H "anthropic-beta: oauth-2025-04-20")
     fi
 
-    HAIKU_RESPONSE=$(curl -s --max-time 15 https://api.anthropic.com/v1/messages \
+    HAIKU_RESPONSE=$(curl -s --max-time 8 https://api.anthropic.com/v1/messages \
         "${auth_args[@]}" \
         -H "anthropic-version: 2023-06-01" \
         -H "content-type: application/json" \
@@ -128,20 +144,26 @@ if [ -n "$COMPACT_SUMMARY" ]; then
                 }]
             }')" 2>/dev/null || true)
 
+    RESUME_CONTENT=""
     if [ -n "$HAIKU_RESPONSE" ]; then
         RESUME_CONTENT=$(echo "$HAIKU_RESPONSE" | jq -r '.content[0].text // ""' 2>/dev/null || true)
-        if echo "$RESUME_CONTENT" | jq empty 2>/dev/null; then
-            # valid JSON
-            jq -n \
-                --arg src "haiku" \
-                --argjson count "$count" \
-                --argjson resume "$RESUME_CONTENT" \
-                '{schema_version: 1, source: $src, compact_count: $count, resume: $resume, created_at: (now | todate)}' \
-                > "$RESUME_FILE"
-            echo "PostCompact: compact_resume.json saved (haiku extraction)" >&2
-        else
-            # Haiku がプレーンテキストを返した場合
-            cat > "$RESUME_FILE" << RESUME
+    fi
+
+    if [ -z "$RESUME_CONTENT" ]; then
+        # curl 失敗 / 空応答 / content 欠落 → 機械抽出へフォールバック（resume 欠落を防ぐ）
+        write_mechanical_resume
+    elif echo "$RESUME_CONTENT" | jq empty 2>/dev/null; then
+        # valid JSON
+        jq -n \
+            --arg src "haiku" \
+            --argjson count "$count" \
+            --argjson resume "$RESUME_CONTENT" \
+            '{schema_version: 1, source: $src, compact_count: $count, resume: $resume, created_at: (now | todate)}' \
+            > "$RESUME_FILE"
+        echo "PostCompact: compact_resume.json saved (haiku extraction)" >&2
+    else
+        # Haiku がプレーンテキストを返した場合
+        cat > "$RESUME_FILE" << RESUME
 {
   "schema_version": 1,
   "source": "haiku_text",
@@ -150,8 +172,7 @@ if [ -n "$COMPACT_SUMMARY" ]; then
   "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 RESUME
-            echo "PostCompact: compact_resume.json saved (haiku text fallback)" >&2
-        fi
+        echo "PostCompact: compact_resume.json saved (haiku text fallback)" >&2
     fi
 fi
 

--- a/dot_config/claude/hooks/executable_post-compact-save.sh
+++ b/dot_config/claude/hooks/executable_post-compact-save.sh
@@ -61,15 +61,37 @@ fi
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 RESUME_FILE="$STATE_DIR/compact_resume.json"
 
-# Haiku API 呼び出しに必要な認証を試みる
+# Haiku API 呼び出しに必要な認証を解決
+# 優先順位: ANTHROPIC_API_KEY (x-api-key) → env OAuth トークン (Bearer)
+#           → keychain OAuth トークン (Bearer)
+# hook プロセスでは env トークンが strip されるため、通常は keychain に落ちる。
+get_keychain_token() {
+    command -v security >/dev/null 2>&1 || return 1
+    local svc raw token expires now
+    svc=$(security dump-keychain 2>/dev/null | grep -oE 'Claude Code-credentials[^"]*' | head -1)
+    if [ -z "$svc" ]; then return 1; fi
+    raw=$(security find-generic-password -s "$svc" -w 2>/dev/null) || return 1
+    token=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+    if [ -z "$token" ]; then return 1; fi
+    expires=$(printf '%s' "$raw" | jq -r '.claudeAiOauth.expiresAt // 0' 2>/dev/null || echo 0)
+    now=$(( $(date +%s) * 1000 ))
+    if [ "$expires" != "0" ] && [ "$expires" -lt "$now" ]; then return 1; fi
+    printf '%s' "$token"
+}
+
 API_KEY="${ANTHROPIC_API_KEY:-}"
+OAUTH_TOKEN=""
 if [ -z "$API_KEY" ]; then
-    # keychain からトークン取得を試みる
-    SESSION_TOKEN="${CLAUDE_CODE_SESSION_ACCESS_TOKEN:-}"
-    if [ -z "$SESSION_TOKEN" ]; then
-        # keychain 経由は shell から複雑なので、compact_summary から機械的に抽出
-        if [ -n "$COMPACT_SUMMARY" ]; then
-            cat > "$RESUME_FILE" << RESUME
+    OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-${CLAUDE_CODE_SESSION_ACCESS_TOKEN:-}}"
+    if [ -z "$OAUTH_TOKEN" ]; then
+        OAUTH_TOKEN=$(get_keychain_token || true)
+    fi
+fi
+
+# 認証が全く取れない場合は compact_summary から機械的に抽出して終了
+if [ -z "$API_KEY" ] && [ -z "$OAUTH_TOKEN" ]; then
+    if [ -n "$COMPACT_SUMMARY" ]; then
+        cat > "$RESUME_FILE" << RESUME
 {
   "schema_version": 1,
   "source": "mechanical",
@@ -78,16 +100,21 @@ if [ -z "$API_KEY" ]; then
   "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 RESUME
-            echo "PostCompact: compact_resume.json saved (mechanical extraction)" >&2
-        fi
-        exit 0
+        echo "PostCompact: compact_resume.json saved (mechanical extraction)" >&2
     fi
+    exit 0
 fi
 
-# API key がある場合は Haiku で構造化抽出
-if [ -n "$API_KEY" ] && [ -n "$COMPACT_SUMMARY" ]; then
+# Haiku で構造化抽出（API key は x-api-key、OAuth トークンは Bearer + beta ヘッダ）
+if [ -n "$COMPACT_SUMMARY" ]; then
+    if [ -n "$API_KEY" ]; then
+        auth_args=(-H "x-api-key: $API_KEY")
+    else
+        auth_args=(-H "authorization: Bearer $OAUTH_TOKEN" -H "anthropic-beta: oauth-2025-04-20")
+    fi
+
     HAIKU_RESPONSE=$(curl -s --max-time 15 https://api.anthropic.com/v1/messages \
-        -H "x-api-key: $API_KEY" \
+        "${auth_args[@]}" \
         -H "anthropic-version: 2023-06-01" \
         -H "content-type: application/json" \
         -d "$(jq -n \

--- a/dot_config/claude/hooks/executable_post-compact-save.sh
+++ b/dot_config/claude/hooks/executable_post-compact-save.sh
@@ -61,10 +61,10 @@ fi
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 RESUME_FILE="$STATE_DIR/compact_resume.json"
 
-# Haiku API 呼び出しに必要な認証を解決
-# 優先順位: ANTHROPIC_API_KEY (x-api-key) → env OAuth トークン (Bearer)
-#           → keychain OAuth トークン (Bearer)
-# hook プロセスでは env トークンが strip されるため、通常は keychain に落ちる。
+# Haiku API 認証: keychain の OAuth トークンのみ。
+# claude ランチャ(dot_config/zsh/dot_zshrc)が CLAUDE_CODE_OAUTH_TOKEN を unset し、
+# ANTHROPIC_API_KEY も未使用のため、env 経由の認証トークンは hook に届かない。
+# (Claude Code はデフォルトでは cred を scrub しない: CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1 が必要)
 
 # compact_summary から機械的に resume を生成（Haiku 不可・失敗・タイムアウト時の共通フォールバック）
 write_mechanical_resume() {
@@ -105,32 +105,20 @@ get_keychain_token() {
     return 1
 }
 
-API_KEY="${ANTHROPIC_API_KEY:-}"
-OAUTH_TOKEN=""
-if [ -z "$API_KEY" ]; then
-    OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-${CLAUDE_CODE_SESSION_ACCESS_TOKEN:-}}"
-    if [ -z "$OAUTH_TOKEN" ]; then
-        OAUTH_TOKEN=$(get_keychain_token || true)
-    fi
-fi
+TOKEN=$(get_keychain_token || true)
 
-# 認証が全く取れない場合は機械抽出で終了
-if [ -z "$API_KEY" ] && [ -z "$OAUTH_TOKEN" ]; then
+# keychain トークンが取れない場合は機械抽出で終了
+if [ -z "$TOKEN" ]; then
     write_mechanical_resume
     exit 0
 fi
 
-# Haiku で構造化抽出（API key は x-api-key、OAuth トークンは Bearer + beta ヘッダ）
+# Haiku で構造化抽出（keychain OAuth トークンを Bearer + beta ヘッダで）。
 # curl の --max-time は PostCompact hook timeout(10s)未満に収め、超過/失敗時は機械抽出へ。
 if [ -n "$COMPACT_SUMMARY" ]; then
-    if [ -n "$API_KEY" ]; then
-        auth_args=(-H "x-api-key: $API_KEY")
-    else
-        auth_args=(-H "authorization: Bearer $OAUTH_TOKEN" -H "anthropic-beta: oauth-2025-04-20")
-    fi
-
     HAIKU_RESPONSE=$(curl -s --max-time 8 https://api.anthropic.com/v1/messages \
-        "${auth_args[@]}" \
+        -H "authorization: Bearer $TOKEN" \
+        -H "anthropic-beta: oauth-2025-04-20" \
         -H "anthropic-version: 2023-06-01" \
         -H "content-type: application/json" \
         -d "$(jq -n \

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
@@ -8,7 +8,7 @@ command=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$command" ] && exit 0
 
 # git add/commit 以外はスルー
-echo "$command" | grep -qE '^git (add|commit)' || exit 0
+echo "$command" | grep -qE '(^|[;&|] *)git (add|commit)' || exit 0
 
 # 明示的な禁止パスを検出
 if echo "$command" | grep -qE '(^|\s)(ai/)'; then

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
-# PreToolUse hook: Block staging/committing forbidden directories
-# 禁止ディレクトリ: ai/
+# PreToolUse hook: 禁止ディレクトリ ai/ のステージ/コミットをブロックする guardrail。
+# 検出: git -C/-c/--no-pager 等の global option・複合コマンド・subshell 経由の add/commit と、
+#       ai/ ./ai/ :/ai/ 形式の pathspec。Claude の誤操作防止が目的（完全な sandbox ではない）。
+# 対象外(意図的): VAR=x 前置の env assignment、bare "ai"(語 "ai" への誤検出回避)、quoted pathspec。
 
 input=$(cat)
 
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$command" ] && exit 0
 
-# git add/commit 以外はスルー（git -C / -c 等のグローバルオプション、複合コマンド・subshell 経由も検出）
-echo "$command" | grep -qE '(^|[;&|(] *)git( +-[Cc][= ]?[^ ]+)* +(add|commit)' || exit 0
+# git add/commit 以外はスルー（global option(-C/-c/--no-pager 等)・複合コマンド・subshell 経由も検出）
+echo "$command" | grep -qE '(^|[;&|(] *)git( +(-[Cc]|--git-dir|--work-tree|--namespace|--exec-path)([= ]+[^ ]+)?| +(--no-pager|--paginate|--bare|-p|-P))* +(add|commit)' || exit 0
 
-# 明示的な禁止パスを検出
-if echo "$command" | grep -qE '(^|\s)(ai/)'; then
+# 明示的な禁止パスを検出（ai/ ./ai/ :/ai/ 形式。別階層の src/ai/ 等は対象外）
+if echo "$command" | grep -qE '(^|[[:space:](])(\.?/|:/)?ai/'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-forbidden-dirs.sh
@@ -7,8 +7,8 @@ input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$command" ] && exit 0
 
-# git add/commit 以外はスルー
-echo "$command" | grep -qE '(^|[;&|] *)git (add|commit)' || exit 0
+# git add/commit 以外はスルー（git -C / -c 等のグローバルオプション、複合コマンド・subshell 経由も検出）
+echo "$command" | grep -qE '(^|[;&|(] *)git( +-[Cc][= ]?[^ ]+)* +(add|commit)' || exit 0
 
 # 明示的な禁止パスを検出
 if echo "$command" | grep -qE '(^|\s)(ai/)'; then

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-# PreToolUse hook: Block git merge commands (bypass-proof)
+# PreToolUse hook: git merge / gh pr merge をブロックする guardrail（Claude の誤操作防止）。
+# 検出: 行頭/区切り(;&|()直後の起動、git -C/-c/--no-pager 等の global option、gh -R/--repo prefix、
+#       複合コマンド・subshell・コマンド置換経由。完全な sandbox ではなく best-effort。
+# 対象外(意図的): 先頭の環境変数代入(VAR=x git merge) — Claude が生成しない adversarial 形。
 
 input=$(cat)
 
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # git merge / gh pr merge をブロック（git mergetool等は許可）
-if echo "$command" | grep -qE '(^|[;&|(] *)(git( +-[Cc][= ]?[^ ]+)* +merge( |$)|gh pr merge( |$))'; then
+if echo "$command" | grep -qE '(^|[;&|(] *)(git( +(-[Cc]|--git-dir|--work-tree|--namespace|--exec-path)([= ]+[^ ]+)?| +(--no-pager|--paginate|--bare|-p|-P))* +merge( |$)|gh( +(-R|--repo)[= ]+[^ ]+)? +pr +merge( |$))'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
@@ -6,7 +6,7 @@ input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # git merge / gh pr merge をブロック（git mergetool等は許可）
-if echo "$command" | grep -qE '^(git merge( |$)|gh pr merge( |$))'; then
+if echo "$command" | grep -qE '(^|[;&|] *)(git merge( |$)|gh pr merge( |$))'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
+++ b/dot_config/claude/hooks/executable_pre-tool-use-block-merge.sh
@@ -6,7 +6,7 @@ input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # git merge / gh pr merge をブロック（git mergetool等は許可）
-if echo "$command" | grep -qE '(^|[;&|] *)(git merge( |$)|gh pr merge( |$))'; then
+if echo "$command" | grep -qE '(^|[;&|(] *)(git( +-[Cc][= ]?[^ ]+)* +merge( |$)|gh pr merge( |$))'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -11,7 +11,7 @@ import Anthropic from "npm:@anthropic-ai/sdk";
 import { readAll } from "jsr:@std/io@0.224/read-all";
 import {
   getGitBranch,
-  getTokenFromKeychain,
+  resolveAnthropicAuth,
 } from "./lib/session-context.ts";
 
 interface SessionStartInput {
@@ -294,17 +294,13 @@ function formatSupplement(data: CompactSupplementInput): string {
 }
 
 async function getApiClient(): Promise<Anthropic | null> {
-  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
-  const sessionToken = Deno.env.get("CLAUDE_CODE_SESSION_ACCESS_TOKEN");
-  const keychainToken =
-    !apiKey && !sessionToken ? await getTokenFromKeychain() : null;
+  const auth = await resolveAnthropicAuth();
+  if (!auth) return null;
 
-  if (!apiKey && !sessionToken && !keychainToken) return null;
-
-  return apiKey
-    ? new Anthropic({ apiKey })
+  return auth.apiKey
+    ? new Anthropic({ apiKey: auth.apiKey })
     : new Anthropic({
-        authToken: sessionToken || keychainToken,
+        authToken: auth.authToken,
         apiKey: null,
         defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
       });

--- a/dot_config/claude/hooks/executable_session-start.ts
+++ b/dot_config/claude/hooks/executable_session-start.ts
@@ -297,13 +297,11 @@ async function getApiClient(): Promise<Anthropic | null> {
   const auth = await resolveAnthropicAuth();
   if (!auth) return null;
 
-  return auth.apiKey
-    ? new Anthropic({ apiKey: auth.apiKey })
-    : new Anthropic({
-        authToken: auth.authToken,
-        apiKey: null,
-        defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
-      });
+  return new Anthropic({
+    authToken: auth.authToken,
+    apiKey: null,
+    defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+  });
 }
 
 async function handleCompact(
@@ -328,7 +326,7 @@ async function handleCompact(
     if (!client) {
       await Deno.stderr.write(
         new TextEncoder().encode(
-          "SessionStart(compact): No API credentials found (no ANTHROPIC_API_KEY, no session token, no keychain token)\n",
+          "SessionStart(compact): No keychain OAuth token found — skipping Haiku supplement\n",
         ),
       );
       if (compactSummary) return; // compact_summary exists, no supplement needed

--- a/dot_config/claude/hooks/executable_stop-hook.ts
+++ b/dot_config/claude/hooks/executable_stop-hook.ts
@@ -2,6 +2,7 @@
 
 import Anthropic from "npm:@anthropic-ai/sdk";
 import { readAll } from "jsr:@std/io@0.224/read-all";
+import { resolveAnthropicAuth } from "./lib/session-context.ts";
 
 interface StopHookInput {
   stop_hook_active?: boolean;
@@ -111,44 +112,6 @@ async function getLastUserRequest(
   return null;
 }
 
-async function getTokenFromKeychain(): Promise<string | null> {
-  try {
-    const dumpCmd = new Deno.Command("security", {
-      args: ["dump-keychain"],
-      stdout: "piped",
-      stderr: "null",
-    });
-    const dumpOutput = await dumpCmd.output();
-    const text = new TextDecoder().decode(dumpOutput.stdout);
-    const services: string[] = [];
-    for (const m of text.matchAll(/"svce"<blob>="(Claude Code-credentials[^"]*)"/g)) {
-      if (!services.includes(m[1])) services.push(m[1]);
-    }
-    for (const svc of services) {
-      try {
-        const cmd = new Deno.Command("security", {
-          args: ["find-generic-password", "-s", svc, "-w"],
-          stdout: "piped",
-          stderr: "null",
-        });
-        const output = await cmd.output();
-        if (!output.success) continue;
-        const raw = new TextDecoder().decode(output.stdout).trim();
-        const creds = JSON.parse(raw);
-        const oauth = creds?.claudeAiOauth;
-        if (!oauth?.accessToken) continue;
-        if (oauth.expiresAt && oauth.expiresAt < Date.now()) continue;
-        return oauth.accessToken;
-      } catch {
-        continue;
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
 async function main(): Promise<void> {
   try {
     const raw = new TextDecoder().decode(await readAll(Deno.stdin));
@@ -163,16 +126,14 @@ async function main(): Promise<void> {
       Deno.exit(0);
     }
 
-    const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
-    const sessionToken = Deno.env.get("CLAUDE_CODE_OAUTH_TOKEN");
-    const keychainToken = (!apiKey && !sessionToken) ? await getTokenFromKeychain() : null;
-    if (!apiKey && !sessionToken && !keychainToken) {
+    const auth = await resolveAnthropicAuth();
+    if (!auth) {
       Deno.exit(0);
     }
-    const client = apiKey
-      ? new Anthropic({ apiKey })
+    const client = auth.apiKey
+      ? new Anthropic({ apiKey: auth.apiKey })
       : new Anthropic({
-          authToken: sessionToken || keychainToken,
+          authToken: auth.authToken,
           apiKey: null,
           defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
         });

--- a/dot_config/claude/hooks/executable_stop-hook.ts
+++ b/dot_config/claude/hooks/executable_stop-hook.ts
@@ -130,13 +130,11 @@ async function main(): Promise<void> {
     if (!auth) {
       Deno.exit(0);
     }
-    const client = auth.apiKey
-      ? new Anthropic({ apiKey: auth.apiKey })
-      : new Anthropic({
-          authToken: auth.authToken,
-          apiKey: null,
-          defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
-        });
+    const client = new Anthropic({
+      authToken: auth.authToken,
+      apiKey: null,
+      defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
+    });
 
     // Extract user's recent request from transcript
     let userContext = "";

--- a/dot_config/claude/hooks/executable_userpromptsubmit-context.sh
+++ b/dot_config/claude/hooks/executable_userpromptsubmit-context.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: workflow instructions + session title from Haiku summary cache
+# UserPromptSubmit hook:
+#   - additionalContext に golden-rules + workflow-instructions + git status + 現在時刻を集約注入
+#   - sessionTitle を Haiku 要約キャッシュ（なければ dir/branch）から設定
+# 旧構成では golden-rules / git status / 時刻を別フックの素の stdout echo で注入しており、
+# シェル依存(`echo '\n'`)があった。本スクリプトに統合し additionalContext JSON へ一本化した。
 set -euo pipefail
 
 # Read stdin JSON to get session_id
@@ -22,6 +26,21 @@ if [ -n "$session_id" ]; then
   fi
 fi
 
-# Read workflow instructions and build output JSON
-content=$(cat ~/.config/claude/hooks/data/workflow-instructions.md 2>/dev/null || echo "")
-echo "$content" | jq -Rs --arg t "$title" '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",additionalContext:.,sessionTitle:$t}}'
+# Assemble context sources（いずれも欠損時は空でフォールバック）
+golden=$(cat ~/.config/claude/hooks/data/golden-rules.txt 2>/dev/null || true)
+workflow=$(cat ~/.config/claude/hooks/data/workflow-instructions.md 2>/dev/null || true)
+
+git_status=""
+if git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git_status=$(git -C "${CLAUDE_PROJECT_DIR:-.}" status --short 2>/dev/null || true)
+fi
+[ -z "$git_status" ] && git_status="（clean）"
+
+now=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Single additionalContext payload（shell 依存の echo '\n' を排し printf で組み立て）
+context=$(printf '%s\n\n%s\n\n## Git status (--short)\n%s\n\n---\nCurrent time: %s\n' \
+  "$golden" "$workflow" "$git_status" "$now")
+
+printf '%s' "$context" | jq -Rs --arg t "$title" \
+  '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",additionalContext:.,sessionTitle:$t}}'

--- a/dot_config/claude/hooks/lib/session-context.ts
+++ b/dot_config/claude/hooks/lib/session-context.ts
@@ -177,6 +177,33 @@ export async function getTokenFromKeychain(): Promise<string | null> {
   }
 }
 
+export interface AnthropicAuth {
+  apiKey?: string;
+  authToken?: string;
+}
+
+/**
+ * Resolve Anthropic API auth for hooks.
+ *
+ * Claude Code strips auth tokens (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN,
+ * CLAUDE_CODE_SESSION_ACCESS_TOKEN) from hook process environments, so inside a
+ * hook the keychain is the effective path. Env vars are still checked first to
+ * support non-hook / manual invocation.
+ *
+ * Returns null when no credential is available.
+ */
+export async function resolveAnthropicAuth(): Promise<AnthropicAuth | null> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (apiKey) return { apiKey };
+
+  const envToken = Deno.env.get("CLAUDE_CODE_OAUTH_TOKEN") ??
+    Deno.env.get("CLAUDE_CODE_SESSION_ACCESS_TOKEN");
+  const token = envToken ?? (await getTokenFromKeychain());
+  if (!token) return null;
+
+  return { authToken: token };
+}
+
 export async function getRecentUserMessages(
   transcriptPath: string,
   maxMessages = 5,

--- a/dot_config/claude/hooks/lib/session-context.ts
+++ b/dot_config/claude/hooks/lib/session-context.ts
@@ -178,29 +178,23 @@ export async function getTokenFromKeychain(): Promise<string | null> {
 }
 
 export interface AnthropicAuth {
-  apiKey?: string;
-  authToken?: string;
+  authToken: string;
 }
 
 /**
  * Resolve Anthropic API auth for hooks.
  *
- * Claude Code strips auth tokens (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN,
- * CLAUDE_CODE_SESSION_ACCESS_TOKEN) from hook process environments, so inside a
- * hook the keychain is the effective path. Env vars are still checked first to
- * support non-hook / manual invocation.
- *
- * Returns null when no credential is available.
+ * In this setup the keychain OAuth token (claude.ai login) is the only usable
+ * credential for hooks: the `claude` launcher unsets CLAUDE_CODE_OAUTH_TOKEN
+ * (see dot_config/zsh/dot_zshrc) and ANTHROPIC_API_KEY is not used, so env auth
+ * tokens never reach hook subprocesses. (Claude Code does NOT scrub credentials
+ * by default — that requires CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1.) Returns a
+ * Bearer authToken, or null when the keychain has no valid token — callers
+ * degrade gracefully.
  */
 export async function resolveAnthropicAuth(): Promise<AnthropicAuth | null> {
-  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
-  if (apiKey) return { apiKey };
-
-  const envToken = Deno.env.get("CLAUDE_CODE_OAUTH_TOKEN") ??
-    Deno.env.get("CLAUDE_CODE_SESSION_ACCESS_TOKEN");
-  const token = envToken ?? (await getTokenFromKeychain());
+  const token = await getTokenFromKeychain();
   if (!token) return null;
-
   return { authToken: token };
 }
 

--- a/dot_config/claude/settings.json.tmpl
+++ b/dot_config/claude/settings.json.tmpl
@@ -285,15 +285,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cat ~/.config/claude/hooks/data/golden-rules.txt 2>/dev/null || true; echo ''; (git -C \"$CLAUDE_PROJECT_DIR\" rev-parse --is-inside-work-tree >/dev/null 2>&1 && git -C \"$CLAUDE_PROJECT_DIR\" status --short) || true; echo '\n---\nCurrent time: '$(date '+%Y-%m-%d %H:%M:%S')",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
             "command": "$HOME/.config/claude/hooks/userpromptsubmit-context.sh",
             "timeout": 5
           }


### PR DESCRIPTION
## 概要

dotfiles の Claude Code hook 設定のブラッシュアップ。認証経路の不整合・post-compact のフォールバック欠落・ブロックフックのバイパス・UserPromptSubmit の旧式注入を修正/統合する。

調査の発端: hook プロセスでは Claude Code が認証トークン (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_CODE_SESSION_ACCESS_TOKEN`) を env から strip することを実機プローブで確認した。hook 内では keychain が実質唯一の認証経路。

## 変更点

### 1. 認証経路の統一 (`784a8aa`)
- `lib/session-context.ts` に `resolveAnthropicAuth()` を追加。優先順位 `API_KEY`(x-api-key) → OAuth env(Bearer) → keychain(Bearer) を一本化。
- env 名の不整合を解消（session-start=`SESSION_ACCESS` / stop-hook=`OAUTH` → 両方許容）。
- `stop-hook.ts` の自前 keychain 取得複製を削除し lib を利用。
- **`post-compact-save.sh` に keychain 経路を追加**（従来 keychain フォールバックが無く、compact resume が常に機械抽出に落ちていた実害を修正）。

### 2. ブロックフックのバイパス修正 (`573789b`, `fccd1d0`, `7538438`)
- 行頭固定だった正規表現を、複合コマンド・subshell・コマンド置換・git/gh global option 対応に拡張。
- `cd x && git merge` / `git -C path merge` / `git --no-pager merge` / `gh -R owner/repo pr merge` / `(...)` / `$(...)` 経由を検出。
- 禁止ディレクトリ検出を `ai/` / `./ai/` / `:/ai/` 形式に拡張（別階層の `src/ai/` 等は対象外）。
- 各フックに threat model（best-effort guardrail・意図的な対象外）をコメントで明文化。
- 意図的な対象外: `VAR=x git ...`（env-prefix）, bare `ai`（語 "ai" への誤検出回避）, quoted pathspec — Claude が生成しない adversarial 形 or FP リスクのため。

### 3. post-compact のフォールバック強化 (`1e877ee`)
- `write_mechanical_resume()` を切り出し、no-auth / API 失敗・空応答・content 欠落の全経路でフォールバック（resume 欠落を防止）。
- curl `--max-time` を 15s→8s（PostCompact hook timeout 10s 内に収める）。
- keychain 探索を全 service 走査へ（lib と同等。実機に `Claude Code-credentials` が 2 件存在することを確認）。

### 4. UserPromptSubmit を additionalContext に一本化 (`f88e6e6`)
- 旧式 stdout echo（`echo '\n'` の shell 依存）の inline フックを廃止し、`userpromptsubmit-context.sh` に golden-rules + workflow + git status + 時刻を集約。2 フック→1 フック。

## 検証

- `deno check` EXIT=0（3 TS + lib、auth narrowing・import 解決を含む）
- `bash -n` 全 shell OK
- 正規表現 30+ ケースのマトリクス + 実フック e2e（deny ベクタ検出 / 通常コマンド・別階層 ai dir・bare ai は素通り / FP なし）
- chezmoi render → valid JSON（UserPromptSubmit が 1 エントリに統合されることを確認）

## レビュー

codex (gpt-5.5 xhigh) でアドバーサリアルレビューを 2 巡実施:
- 1 巡目で指摘された認証フォールバック欠落(high)・keychain 先頭のみ(medium)・bypass(blocker) を修正。
- 2 巡目で認証系は解決を確認。残る指摘はブロックフックの正規表現「完全性」（さらに別表記のバイパス）。
- 現実的に Claude が生成するベクタは全て対応・テスト済み。残る理論的バイパス（env-prefix 等）は best-effort guardrail の設計上の対象外として明文化した。codex の verdict は完全性観点で block だが、これは regex ガードに対する原理的なもので、最終的な厳格化方針は repo owner の判断に委ねる。

## デプロイ

マージ後 `chezmoi apply` で `~/.config/claude/` に反映される（本セッションは旧 hook のまま動作中で、変更は未適用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
