### PR TITLE
feat(claude): stop-hook に反復ディレクティブ自動検出を追加（自動 goal 挙動）

### DIFF
--- a/dot_config/claude/hooks/executable_stop-hook.ts
+++ b/dot_config/claude/hooks/executable_stop-hook.ts
@@ -2,7 +2,11 @@
 
 import Anthropic from "npm:@anthropic-ai/sdk";
 import { readAll } from "jsr:@std/io@0.224/read-all";
-import { resolveAnthropicAuth } from "./lib/session-context.ts";
+import {
+  resolveAnthropicAuth,
+  isRealUserMessage,
+  extractTextFromContent,
+} from "./lib/session-context.ts";
 
 interface StopHookInput {
   stop_hook_active?: boolean;
@@ -21,6 +25,38 @@ interface TranscriptEntry {
   message?: {
     content: string | Array<{ type: string; text?: string }>;
   };
+}
+
+/**
+ * ユーザーの直近リクエストに「明示的な反復/ループ指示」があるか高精度に判定する。
+ * 検出時は stop-hook が「終了条件が満たされるまで継続を強制」する自動 goal 挙動に入る
+ * (手動 /goal なしでループ駆動する。ただし CC の連続 block 上限 8 回で頭打ち=長いループは /goal を使う)。
+ * 誤爆(=本当はループでない指示で延々 block)を避けるため、語のホワイトリストで絞る。
+ */
+const LOOP_PATTERNS: RegExp[] = [
+  /繰り返(して|す(?:$|[。、\s])|せ)/, // 命令形/節末のみ。名詞「繰り返しの/処理」は除外
+  /(なくなる|無くなる|出なくなる|ゼロになる|0になる|消える|通る|直る|収束(する)?|終わる|パスする|グリーンになる|green になる)まで(?![のに])/, // 「までの/までに」(説明文)は除外
+  /ループ(して|で回|させ|を回)/,
+  /\b(repeat|loop)\s+until\b/i,
+  /\bkeep\s+(going|iterating|repeating|running|trying|fixing)\b/i,
+  // until + (60字以内の)成功語: "until tests pass" 等を拾う
+  /\buntil\b[\s\S]{0,60}?\b(pass(?:es|ing)?|succeed|success|clean|resolved|done|green|gone|zero|no\s+(?:findings|errors|issues|failures))\b/i,
+];
+
+export function detectLoopDirective(text: string): boolean {
+  return !!text && LOOP_PATTERNS.some((re) => re.test(text));
+}
+
+/** マッチした反復ディレクティブ周辺を抜き出す(userContext が 500字で切られても終了条件を haiku に渡すため) */
+export function loopDirectiveSnippet(text: string): string {
+  for (const re of LOOP_PATTERNS) {
+    const m = text.match(re);
+    if (m && m.index !== undefined) {
+      const s = Math.max(0, m.index - 40);
+      return text.slice(s, m.index + m[0].length + 40).trim();
+    }
+  }
+  return "";
 }
 
 const STOP_DECISION_TOOL: Anthropic.Tool = {
@@ -69,39 +105,23 @@ When you APPROVE stop (should_stop=true), also set done_summary: a 15-40 charact
 Call stop_decision with your judgment.`;
 
 /** Read the last user text message from the transcript JSONL */
-async function getLastUserRequest(
+export async function getLastUserRequest(
   transcriptPath: string,
 ): Promise<string | null> {
   try {
     const content = await Deno.readTextFile(transcriptPath);
     const lines = content.trimEnd().split("\n");
 
-    // Scan from the end to find the last user message with actual text
+    // 末尾から走査し **本物のユーザー発話のみ** 返す。Stop hook feedback / [Request interrupted] /
+    // コマンド出力等のシステム生成メッセージは isRealUserMessage で除外する。
+    // (除外しないと、ループ2周目以降に "Stop hook feedback:" を直近リクエストと誤認し反復検出が落ちる)
     for (let i = lines.length - 1; i >= 0; i--) {
       try {
         const entry: TranscriptEntry = JSON.parse(lines[i]);
         if (entry.type !== "user" || !entry.message?.content) continue;
-
-        const msgContent = entry.message.content;
-        if (typeof msgContent === "string") {
-          const text = msgContent.trim();
-          if (text && !text.startsWith("[Request interrupted")) return text;
-          continue;
-        }
-
-        if (Array.isArray(msgContent)) {
-          // Extract text blocks, skip tool_result
-          const texts = msgContent
-            .filter(
-              (b) =>
-                b.type === "text" &&
-                b.text &&
-                !b.text.startsWith("[Request interrupted"),
-            )
-            .map((b) => b.text!.trim())
-            .filter((t) => t.length > 0);
-          if (texts.length > 0) return texts.join("\n");
-        }
+        if (!isRealUserMessage(entry.message.content)) continue;
+        const text = extractTextFromContent(entry.message.content).trim();
+        if (text) return text;
       } catch {
         // skip malformed lines
       }
@@ -117,7 +137,16 @@ async function main(): Promise<void> {
     const raw = new TextDecoder().decode(await readAll(Deno.stdin));
     const input: StopHookInput = JSON.parse(raw);
 
-    if (input.stop_hook_active) {
+    // 反復ディレクティブ検出のため先にユーザー直近リクエストを読む
+    const userRequest = input.transcript_path
+      ? await getLastUserRequest(input.transcript_path)
+      : null;
+    const loopActive = userRequest ? detectLoopDirective(userRequest) : false;
+
+    // 通常は stop_hook_active で早期 exit(2連続 block 防止の慣習)。
+    // ただし反復ディレクティブが有効な間は継続を駆動するため早期 exit しない
+    // (終了条件が満たされるか、CC の連続 block 上限=既定8回に達するまで block し続ける)。
+    if (input.stop_hook_active && !loopActive) {
       Deno.exit(0);
     }
 
@@ -136,18 +165,15 @@ async function main(): Promise<void> {
       defaultHeaders: { "anthropic-beta": "oauth-2025-04-20" },
     });
 
-    // Extract user's recent request from transcript
+    // userContext は先に取得済みの userRequest から構築
     let userContext = "";
-    if (input.transcript_path) {
-      const userRequest = await getLastUserRequest(input.transcript_path);
-      if (userRequest) {
-        // Truncate to keep token usage reasonable
-        const truncated =
-          userRequest.length > 500
-            ? userRequest.slice(0, 500) + "..."
-            : userRequest;
-        userContext = `User's recent request:\n${truncated}\n\n`;
-      }
+    if (userRequest) {
+      // Truncate to keep token usage reasonable
+      const truncated =
+        userRequest.length > 500
+          ? userRequest.slice(0, 500) + "..."
+          : userRequest;
+      userContext = `User's recent request:\n${truncated}\n\n`;
     }
 
     // Check for verification evidence
@@ -205,6 +231,16 @@ async function main(): Promise<void> {
       // No health data available
     }
 
+    // 反復ディレクティブが有効なら、終了条件の証拠が無い限り継続を強制する指示を足す
+    const loopSnippet = loopActive && userRequest
+      ? loopDirectiveSnippet(userRequest)
+      : "";
+    const loopNote = loopActive
+      ? `\n\nLOOP DIRECTIVE ACTIVE: ユーザーの直近リクエストに明示的な反復/ループ指示がある${
+          loopSnippet ? `（該当: "${loopSnippet}"）` : ""
+        }。should_stop は **false(継続)** にすること。例外は、Claude の最終メッセージに「ループの終了条件が満たされた具体的証拠」がある場合のみ — 例: レビュアー/codex が指摘ゼロを報告("指摘なし" / "no findings" / "0 件")、テスト全通過、目標状態に到達した確証。完了っぽい要約だけで証拠が無ければ継続(false)。なお、その指示がこの会話の進行中の反復タスクに実際には対応していない(既に終了/別件)なら stop を承認(true)してよい。`
+      : "";
+
     const response = await client.messages.create({
       model: "claude-haiku-4-5-20251001",
       max_tokens: 256,
@@ -214,7 +250,7 @@ async function main(): Promise<void> {
       messages: [
         {
           role: "user",
-          content: `${userContext}Claude's last assistant message:\n\n${lastMessage}${verificationNote}${healthNote}`,
+          content: `${userContext}Claude's last assistant message:\n\n${lastMessage}${verificationNote}${healthNote}${loopNote}`,
         },
       ],
     });
@@ -278,4 +314,7 @@ async function main(): Promise<void> {
   Deno.exit(0);
 }
 
-main();
+// 直接実行時のみ起動(import 時=テスト時は走らせない)
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## 概要

ユーザーが「〜まで繰り返して」等の**反復指示**を出したら、手動 `/goal` なしで `stop-hook.ts` が
**終了条件まで自動で継続を駆動**する（＝自動 goal 挙動）。

## 背景（なぜ必要か）

現 `stop-hook.ts` は `if (stop_hook_active) exit 0` で **1回しか block しない**設計のため、多周ループを回せなかった
（「指摘ゼロまで繰り返して」が1〜2周で早期停止しうる）。`/goal` は純正解だが**手動**。本 PR は反復指示を自動検出して
stop-hook 側でループを駆動する。

公式仕様で確認: Stop hook の多周ループは `{"decision":"block"}` で可能。ただし**連続 block 上限（既定8回, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`）**があり、超長ループは引き続き `/goal`（上限回避）を使う。

## 変更（`dot_config/claude/hooks/executable_stop-hook.ts` のみ）

- `detectLoopDirective()`: 反復ディレクティブを高精度検出（`繰り返して` / `〜がなくなるまで` / `until ... pass` / `keep iterating` 等）。名詞「繰り返しの設定/処理」「〜までの/に」(説明文)は除外。
- loop 検出時は `stop_hook_active` でも早期 exit せず、**終了条件の証拠**（codex 指摘ゼロ / 全テスト通過 等）が最終メッセージに現れるまで `block` で継続。完了っぽい要約だけでは止めない。
- `getLastUserRequest` を共通 `isRealUserMessage` ベースに変更し、`"Stop hook feedback:"` 等のシステム生成メッセージを除外。
- `loopDirectiveSnippet` で該当指示を判定 prompt に同梱（500字切り詰めでも終了条件を渡す）。
- `import.meta.main` ガードで testable 化。**非ループタスクの挙動は不変**。

## codex review で検出・修正した4件

| # | 重大度 | 内容 | 修正 |
|---|---|---|---|
| 1 | **high** | 2周目以降、最新の user エントリが `"Stop hook feedback:"` になり、それを直近リクエストと誤認 → `loopActive=false` でループが死ぬ | `isRealUserMessage` で除外 |
| 2 | medium | 「〜までの/に」(説明文)を loop と誤検出 | `まで(?![のに])` + 冗長な pattern 削除 |
| 3 | medium | 英語 `until tests pass` を見逃し | until + 60字窓の成功語マッチ |
| 4 | medium | 500字切り詰めで終了条件が haiku に渡らない | `loopDirectiveSnippet` を prompt 同梱 |

## 検証（実挙動で確認。self-test/ロジックだけで完成宣言しない）

- `deno check` 通過。
- `detectLoopDirective` 単体7ケース PASS（名詞誤検出・までの除外・until 検出を含む）。
- **現実的 round-2 transcript**（最新 user = `Stop hook feedback:`、`stop_hook_active=true`、非終了メッセージ）→ `decision=block` を確認＝**多周ループが実際に回る**。終了条件あり（codex 指摘ゼロ）→ 停止許可。
- `getLastUserRequest` が feedback をスキップし元指示を返すことを決定的に確認。
- 非ループ + `stop_hook_active=true` → 従来通り早期 exit（不変）。

> ⚠ 初回の behavioral test は「最後の user＝指示」という非現実な transcript で #1 を見逃した。codex review が捕捉し、**現実的な round-2 transcript で再検証**した。

## 反映

`stop-hook.ts` は hook。マージ→`chezmoi apply`→**再起動**で有効化（settings の hook 変更ではなくスクリプト本体なので、次回 Stop から効くが、確実にするため再起動推奨）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
